### PR TITLE
Fixed a pesky camera bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ function TSNext() {
           <PlotSolarSystem />
           <TraceController />
           <CopyPosToClipb />
-          <axesHelper args={[5]} position={[0, 0, 0]} />
+          {/* <axesHelper args={[5]} position={[0, 0, 0]} /> */}
           {/* <ExoplanetStars /> */}
           <AsteroidBelt />
         </Suspense>

--- a/src/components/CustomCameraControls.tsx
+++ b/src/components/CustomCameraControls.tsx
@@ -7,9 +7,9 @@ import { Vector3 } from "three";
 const OrbitCamera = () => {
   const cameraTarget = useStore((s) => s.cameraTarget);
   const cameraFollow = useStore((s) => s.cameraFollow);
-  // const cameraFollow = true;
+  const planetCamera = useStore((s) => s.planetCamera);
   const target = new Vector3();
-  const { scene } = useThree();
+  const { scene, camera } = useThree();
   const cameraControlsRef = useRef<CameraControls>(null);
   const targetObjRef = useRef(null);
 
@@ -17,7 +17,7 @@ const OrbitCamera = () => {
     targetObjRef.current = scene.getObjectByName(cameraTarget);
     targetObjRef.current.getWorldPosition(target);
     cameraControlsRef.current.setTarget(target.x, target.y, target.z, false);
-  }, [cameraTarget]);
+  }, [cameraTarget, camera]);
 
   useLayoutEffect(() => {
     cameraControlsRef.current.smoothTime = 2;
@@ -31,11 +31,20 @@ const OrbitCamera = () => {
     }
   });
 
-  return <CameraControls ref={cameraControlsRef} maxDistance={80000} />;
+  return (
+    <CameraControls
+      ref={cameraControlsRef}
+      maxDistance={80000}
+      // if planetCamera is active we camera controls should be diabled
+      enabled={!planetCamera}
+    />
+  );
 };
 
 export default function CustomCameraControls() {
-  const planetCamera = useStore((s) => s.planetCamera);
-
-  return <>{planetCamera ? null : <OrbitCamera />}</>;
+  return (
+    <>
+      <OrbitCamera />
+    </>
+  );
 }

--- a/src/settings/misc-settings.json
+++ b/src/settings/misc-settings.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "SystemCenter",
-    "color": "darkGrey",
+    "color": "black",
     "type": "planet",
     "visible": true,
     "texture": "",


### PR DESCRIPTION
Fixed a pesky bug that prevented the system camera from having the right target after a switch to planet camera. After trying everything all that was needed was to add camera as a dependency in the useLayoutEffect in customCameraCotrols!